### PR TITLE
Add different messages for merged v. unmerged PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Perhaps you maintain a project with many contributors and you'd like to keep sta
 You can use the [default responses](https://github.com/teacher-bot/teacherbot/blob/master/index.js), but if you'd like to specify your own, create a file inside a `.github` folder, named `teacherbot.yml` and include the following text:
 
 ```yml
-remindMerge: 
-    message: ":wave: hiya Please remember to delete your branch after merging or closing if you haven't done so already."
+remindMerge:
+    merged: ":wave: hiya Please remember to delete your branch after merging or closing if you haven't done so already.",
+    unmerged: "It looks like you closed this Pull Request without merging. If you need any help, just ask!"
 ```
 
 ### Running your own instance of this app

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ Perhaps you maintain a project with many contributors and you'd like to keep sta
 You can use the [default responses](https://github.com/teacher-bot/teacherbot/blob/master/index.js), but if you'd like to specify your own, create a file inside a `.github` folder, named `teacherbot.yml` and include the following text:
 
 ```yml
-remindMerge:
-    merged: ":wave: hiya Please remember to delete your branch after merging or closing if you haven't done so already.",
-    unmerged: "It looks like you closed this Pull Request without merging. If you need any help, just ask!"
+merged: ":wave: hiya Please remember to delete your branch after merging or closing if you haven't done so already.",
+unmerged: "It looks like you closed this Pull Request without merging. If you need any help, just ask!"
 ```
 
 ### Running your own instance of this app

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Add issue openers as collaborators
 
-This [Probot](https://github.com/probot/probot/) [plugin](https://github.com/probot/probot/#plugins) automatically reminds users to delete their branch after the merge or close a pull request.
+This [Probot](https://github.com/probot/probot/) [plugin](https://github.com/probot/probot/#plugins) automatically reminds users to delete their branch after the merge or close a pull request. It can be used by itself, or as part of a collection of plugins called [Teacherbot](https://github.com/teacher-bot/teacherbot/).
 
 ### But why?
 
@@ -8,6 +8,7 @@ Perhaps you maintain a project with many contributors and you'd like to keep sta
 
 ### Features
 
+- Responds to pull requests that are closed without merging.
 - Responds to recently merged pull requests.
 - Allows for customized responses.
 
@@ -18,11 +19,15 @@ Perhaps you maintain a project with many contributors and you'd like to keep sta
 
 ### Configuring Customized Responses
 
-You can use the [default responses](https://github.com/teacher-bot/teacherbot/blob/master/index.js), but if you'd like to specify your own, create a file inside a `.github` folder, named `teacherbot.yml` and include the following text:
+You can use the [default responses](https://github.com/teacher-bot/teacherbot/blob/master/index.js), but if you'd like to specify your own:
+
+- If you're using this plugin as part of [Teacherbot](https://github.com/teacher-bot/teacherbot/): create a file inside a `.github` folder, named `teacherbot.yml` and include the text below.
+- If you're using this plugin standalone: create a file inside a `.github` folder, named `remind-merge.yml` and include the text below.
 
 ```yml
-merged: ":wave: hiya Please remember to delete your branch after merging or closing if you haven't done so already.",
-unmerged: "It looks like you closed this Pull Request without merging. If you need any help, just ask!"
+remindMerge:
+  merged: ":wave: hiya Please remember to delete your branch after merging or closing if you haven't done so already.",
+  unmerged: "It looks like you closed this Pull Request without merging. If you need any help, just ask!"
 ```
 
 ### Running your own instance of this app

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const defaultsShape = {
-  message: 'string',
+  merged: 'string',
+  unmerged: 'string'
 };
 
 function checkForDefaults(defaults) {
@@ -20,7 +21,11 @@ module.exports = (robot, defaults, configFilename = 'remind-merge.yml') => {
   checkForDefaults(defaults);
 
   robot.on('pull_request.closed', async context => {
+
     const {number} = context.payload;
+
+    // separate whether the pull request was merged or not
+    const merged = context.payload.pull_request.merged;
 
     let config;
     try {
@@ -32,7 +37,7 @@ module.exports = (robot, defaults, configFilename = 'remind-merge.yml') => {
 
     return context.github.issues.createComment(context.repo({
       number,
-      body: config.message
+      body: merged ? config.merged : config.unmerged
     }));
   });
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function checkForDefaults(defaults) {
  * @param {Config} defaults
  * @param {String} [configFilename]
  */
-module.exports = (robot, defaults = {merged: "You've merged!", unmerged: "You didn't merge."}, configFilename = 'remind-merge.yml') => {
+module.exports = (robot, defaults = {merged: "Congratulations! You've merged!", unmerged: "You haven't merged yet, don't forget you can ask for help."}, configFilename = 'remind-merge.yml') => {
   checkForDefaults(defaults);
 
   robot.on('pull_request.closed', async context => {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function checkForDefaults(defaults) {
  * @param {Config} defaults
  * @param {String} [configFilename]
  */
-module.exports = (robot, defaults, configFilename = 'remind-merge.yml') => {
+module.exports = (robot, defaults = {merged: "You've merged!", unmerged: "You didn't merge."}, configFilename = 'remind-merge.yml') => {
   checkForDefaults(defaults);
 
   robot.on('pull_request.closed', async context => {


### PR DESCRIPTION
This PR allows `remind-merge` to respond differently depending on whether the PR it's responding to has been merged, or closed without merging.

@teacher-bot/training-team 👀 please